### PR TITLE
Fixed sourcemaps (and bump autoprefixer version)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -26,8 +26,8 @@ gulp.task('css:clean', function(){
 gulp.task('css:compile', ['css:clean'], function(){
     return gulp
         .src('src/scss/index.scss') // this is the source of for compilation
-        .pipe(sass().on('error', sass.logError)) // compile sass to css and also tell us about a problem if happens
         .pipe(sourcemaps.init()) // initalizes a sourcemap
+        .pipe(sass().on('error', sass.logError)) // compile sass to css and also tell us about a problem if happens
         .pipe(postcss([autoprefixer( // supported browsers (from Bootstrap 4 beta: https://github.com/twbs/bootstrap/blob/v4-dev/build/postcss.config.js)
             //
             // Official browser support policy:
@@ -49,7 +49,7 @@ gulp.task('css:compile', ['css:clean'], function(){
             'Opera >= 30'
         ), require('postcss-flexbugs-fixes')]))
         .pipe(csso()) // compresses CSS
-        .pipe(sourcemaps.write('.')) // writes the sourcemap
+        .pipe(sourcemaps.write('./dist')) // writes the sourcemap
         .pipe(gulp.dest('./dist')) // destination of the resulting css
         .pipe(browserSync.stream()); // tell browsersync to reload CSS (injects compiled CSS)
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -250,26 +250,59 @@
       "dev": true
     },
     "autoprefixer": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.1.6.tgz",
-      "integrity": "sha512-C9yv/UF3X+eJTi/zvfxuyfxmLibYrntpF3qoJYrMeQwgUJOZrZvpJiMG2FMQ3qnhWtF/be4pYONBBw95ZGe3vA==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.2.2.tgz",
+      "integrity": "sha512-eTVoSHiGp2cDytg7RS7gtqAnfH+WFcNQMTjywGNu+hH7ViQZ/ZKsvNz2C1oVhCtd9DjMIC15iatpxmtp5Kxvpg==",
       "dev": true,
       "requires": {
-        "browserslist": "2.5.1",
-        "caniuse-lite": "1.0.30000755",
+        "browserslist": "2.10.0",
+        "caniuse-lite": "1.0.30000780",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
-        "postcss": "6.0.13",
+        "postcss": "6.0.14",
         "postcss-value-parser": "3.3.0"
       },
       "dependencies": {
-        "postcss": {
-          "version": "6.0.13",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.13.tgz",
-          "integrity": "sha512-nHsrD1PPTMSJDfU+osVsLtPkSP9YGeoOz4FDLN4r1DW4N5vqL1J+gACzTQHsfwIiWG/0/nV4yCzjTMo1zD8U1g==",
+        "browserslist": {
+          "version": "2.10.0",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.10.0.tgz",
+          "integrity": "sha512-WyvzSLsuAVPOjbljXnyeWl14Ae+ukAT8MUuagKVzIDvwBxl4UAwD1xqtyQs2eWYPGUKMeC3Ol62goqYuKqTTcw==",
           "dev": true,
           "requires": {
-            "chalk": "2.1.0",
+            "caniuse-lite": "1.0.30000780",
+            "electron-to-chromium": "1.3.28"
+          }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30000780",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000780.tgz",
+          "integrity": "sha1-H5CV8u/UlA4LpsWZKreptkzDW6Q=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "electron-to-chromium": {
+          "version": "1.3.28",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.28.tgz",
+          "integrity": "sha1-jdTmRYCGZE6fnwoc8y4qH53/2e4=",
+          "dev": true
+        },
+        "postcss": {
+          "version": "6.0.14",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
+          "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.3.0",
             "source-map": "0.6.1",
             "supports-color": "4.5.0"
           }
@@ -473,16 +506,6 @@
         "weinre": "2.0.0-pre-I0Z7U9OV"
       }
     },
-    "browserslist": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.5.1.tgz",
-      "integrity": "sha512-jAvM2ku7YDJ+leAq3bFH1DE0Ylw+F+EQDq4GkqZfgPEqpWYw9ofQH85uKSB9r3Tv7XDbfqVtE+sdvKJW7IlPJA==",
-      "dev": true,
-      "requires": {
-        "caniuse-lite": "1.0.30000755",
-        "electron-to-chromium": "1.3.27"
-      }
-    },
     "bs-recipes": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/bs-recipes/-/bs-recipes-1.3.4.tgz",
@@ -524,12 +547,6 @@
           "dev": true
         }
       }
-    },
-    "caniuse-lite": {
-      "version": "1.0.30000755",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000755.tgz",
-      "integrity": "sha1-nOX24GvXXsggmr6IU8O+7wIkjWU=",
-      "dev": true
     },
     "caseless": {
       "version": "0.12.0",
@@ -1063,12 +1080,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
-      "dev": true
-    },
-    "electron-to-chromium": {
-      "version": "1.3.27",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.27.tgz",
-      "integrity": "sha1-eOy4o5kGYYe7N07t412ccFZagD0=",
       "dev": true
     },
     "emitter-steward": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "devDependencies": {
-    "autoprefixer": "^7.1.6",
+    "autoprefixer": "^7.2.2",
     "bootstrap": "^4.0.0-beta",
     "browser-sync": "^2.18.13",
     "del": "^3.0.0",


### PR DESCRIPTION
You can enjoy sourcemaps power now.

Sourcemaps must be initialized as documentation specifies: https://github.com/gulp-sourcemaps/gulp-sourcemaps#usage

Also fixed location of .map file to the same folder as resulting css.